### PR TITLE
#213 - Improve COM initialization logic to not fail if already initialized

### DIFF
--- a/include/audiodecodermediafoundation.h
+++ b/include/audiodecodermediafoundation.h
@@ -52,9 +52,9 @@
 
 #include "audiodecoderbase.h"
 
-class IMFSourceReader;
-class IMFMediaType;
-class IMFMediaSource;
+struct IMFSourceReader;
+struct IMFMediaType;
+struct IMFMediaSource;
 
 #define SHORT_SAMPLE short
 
@@ -91,6 +91,7 @@ class DllExport AudioDecoderMediaFoundation : public AudioDecoderBase {
     bool m_seeking;
 	unsigned int m_iBitsPerSample;
 	SHORT_SAMPLE m_destBufferShort[8192];
+    bool m_com_preinitialized = false;
 };
 
 #endif // ifndef AUDIODECODERMEDIAFOUNDATION_H


### PR DESCRIPTION
These changes are actually taken from the PortAudio API which has some more robust logic that deals with the case the COM is already initialized. Essentially, it checks the `CoInitializeEx()` call return. If its been initialized to some other configuration, we no longer treat it as an error and we also don't uninitialized in the destructor call. This logic is needed for https://github.com/HatterCorp/Alyce/pull/251 to work more seamlessly.